### PR TITLE
writing directly to binary file for speedup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 2.8.4)
+project(louvain-community)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++03")
+
+include_directories(./)
+
+add_executable(community
+        main_community.cpp
+        graph_binary.h
+        community.h
+        community.cpp
+        graph_binary.cpp
+        graph.cpp
+        graph.h
+        )
+
+add_executable(convert
+        main_convert.cpp
+        graph.h
+        graph.cpp
+        )
+
+add_executable(hierarchy
+        main_hierarchy.cpp
+        )

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 CC=g++
-CFLAGS= -ansi -O5 -Wall
-LDFLAGS= -ansi -lm -Wall
+CFLAGS= -std=c++11 -O5 -Wall
+LDFLAGS= -std=c++11 -lm -Wall
 EXEC=community convert hierarchy
 OBJ1= graph_binary.o community.o
 OBJ2= graph.o

--- a/Makefile
+++ b/Makefile
@@ -3,19 +3,19 @@
 CC=g++
 CFLAGS= -std=c++11 -O5 -Wall
 LDFLAGS= -std=c++11 -lm -Wall
-EXEC=community convert hierarchy
+EXEC=linux-community linux-convert linux-hierarchy
 OBJ1= graph_binary.o community.o
 OBJ2= graph.o
 
 all: $(EXEC)
 
-community : $(OBJ1) main_community.o
+linux-community : $(OBJ1) main_community.o
 	$(CC) -o $@ $^ $(LDFLAGS)
 
-convert : $(OBJ2) main_convert.o
+linux-convert : $(OBJ2) main_convert.o
 	$(CC) -o $@ $^ $(LDFLAGS)
 
-hierarchy : main_hierarchy.o
+linux-hierarchy : main_hierarchy.o
 	$(CC) -o $@ $^ $(LDFLAGS)
 
 ##########################################

--- a/graph.cpp
+++ b/graph.cpp
@@ -157,20 +157,20 @@ Graph::display_binary(char *filename, char *filename_w, uint32_t type) {
   uint32_t s = links.size();
 
   // outputs number of nodes
-  foutput.write((char *)(&s),4);
+  foutput.write((char *)(&s),sizeof(s));
 
   // outputs cumulative degree sequence
   long tot=0;
   for (uint32_t i=0 ; i<s ; i++) {
     tot+=(long)links[i].size();
-    foutput.write((char *)(&tot),8);
+    foutput.write((char *)(&tot),sizeof(tot));
   }
 
   // outputs links
   for (uint32_t i=0 ; i<s ; i++) {
     for (uint32_t j=0 ; j<links[i].size() ; j++) {
       uint32_t dest = links[i][j].first;
-      foutput.write((char *)(&dest),4);
+      foutput.write((char *)(&dest),sizeof(dest));
     }
   }
   foutput.close();
@@ -182,7 +182,7 @@ Graph::display_binary(char *filename, char *filename_w, uint32_t type) {
     for (uint32_t i=0 ; i<s ; i++) {
       for (uint32_t j=0 ; j<links[i].size() ; j++) {
 	float weight = links[i][j].second;
-	foutput_w.write((char *)(&weight),4);
+	foutput_w.write((char *)(&weight),sizeof(weight));
       }
     }
     foutput_w.close();

--- a/graph.cpp
+++ b/graph.cpp
@@ -31,59 +31,80 @@
 
 using namespace std;
 
-Graph::Graph(char *filename, int type) {
+Graph::Graph(char *filename, uint32_t type) {
   ifstream finput;
-  finput.open(filename,fstream::in);
+  finput.open(filename,fstream::in | fstream::binary);
+  if (!finput.is_open())
+  {
+    std::cerr << "failed to open file\n";
+    return;
+  }
 
-  int nb_links=0;
+  uint32_t nb_links=0;
 
-  while (!finput.eof()) {
-    unsigned int src, dest;
+  while (true) {
+    uint32_t src, dest;
     double weight=1.;
 
-    if (type==WEIGHTED) {
-      finput >> src >> dest >> weight;
-    } else {
-      finput >> src >> dest;
+
+    if (type==WEIGHTED) 
+    {
+      finput.read((char*) &src, sizeof(src));
+      if (finput.eof())
+        break;
+      assert(finput.rdstate() == ios::goodbit);
+      finput.read((char*) &dest, sizeof(dest));
+      assert(finput.rdstate() == ios::goodbit);
+      finput.read((char*) &weight, sizeof(weight));
+      assert(finput.rdstate() == ios::goodbit);
+    } 
+    else
+    {
+      finput.read((char*) &src, sizeof(src));
+      if (finput.eof())
+        break;
+      assert(finput.rdstate() == ios::goodbit);
+      finput.read((char*) &dest, sizeof(dest));
+      assert(finput.rdstate() == ios::goodbit);
     }
     
-    if (finput) {
-      if (links.size()<=max(src,dest)+1) {
-        links.resize(max(src,dest)+1);
-      }
-      
-      links[src].push_back(make_pair(dest,weight));
-      if (src!=dest)
-        links[dest].push_back(make_pair(src,weight));
-
-      nb_links++;
+    
+    if (links.size()<=max(src,dest)+1) {
+      links.resize(max(src,dest)+1);
     }
+      
+    links[src].push_back(make_pair(dest,weight));
+    if (src!=dest)
+      links[dest].push_back(make_pair(src,weight));
+
+    nb_links++;
+     
   }
 
   finput.close();
 }
 
 void
-Graph::renumber(int type) {
-  vector<int> linked(links.size(),-1);
-  vector<int> renum(links.size(),-1);
-  int nb=0;
+Graph::renumber(uint32_t type) {
+  vector<uint32_t> linked(links.size(),-1);
+  vector<uint32_t> renum(links.size(),-1);
+  uint32_t nb=0;
   
-  for (unsigned int i=0 ; i<links.size() ; i++) {
-    for (unsigned int j=0 ; j<links[i].size() ; j++) {
+  for (uint32_t i=0 ; i<links.size() ; i++) {
+    for (uint32_t j=0 ; j<links[i].size() ; j++) {
       linked[i]=1;
       linked[links[i][j].first]=1;
     }
   }
   
-  for (unsigned int i=0 ; i<links.size() ; i++) {
+  for (uint32_t i=0 ; i<links.size() ; i++) {
     if (linked[i]==1)
       renum[i]=nb++;
   }
 
-  for (unsigned int i=0 ; i<links.size() ; i++) {
+  for (uint32_t i=0 ; i<links.size() ; i++) {
     if (linked[i]==1) {
-      for (unsigned int j=0 ; j<links[i].size() ; j++) {
+      for (uint32_t j=0 ; j<links[i].size() ; j++) {
 	links[i][j].first = renum[links[i][j].first];
       }
       links[renum[i]]=links[i];
@@ -93,12 +114,12 @@ Graph::renumber(int type) {
 }
 
 void
-Graph::clean(int type) {
-  for (unsigned int i=0 ; i<links.size() ; i++) {
-    map<int, float> m;
-    map<int, float>::iterator it;
+Graph::clean(uint32_t type) {
+  for (uint32_t i=0 ; i<links.size() ; i++) {
+    map<uint32_t, float> m;
+    map<uint32_t, float>::iterator it;
 
-    for (unsigned int j=0 ; j<links[i].size() ; j++) {
+    for (uint32_t j=0 ; j<links[i].size() ; j++) {
       it = m.find(links[i][j].first);
       if (it==m.end())
 	m.insert(make_pair(links[i][j].first, links[i][j].second));
@@ -106,7 +127,7 @@ Graph::clean(int type) {
       	it->second+=links[i][j].second;
     }
     
-    vector<pair<int,float> > v;
+    vector<pair<uint32_t,float> > v;
     for (it = m.begin() ; it!=m.end() ; it++)
       v.push_back(*it);
     links[i].clear();
@@ -115,9 +136,9 @@ Graph::clean(int type) {
 }
 
 void
-Graph::display(int type) {
-  for (unsigned int i=0 ; i<links.size() ; i++) {
-    for (unsigned int j=0 ; j<links[i].size() ; j++) {
+Graph::display(uint32_t type) {
+  for (uint32_t i=0 ; i<links.size() ; i++) {
+    for (uint32_t j=0 ; j<links[i].size() ; j++) {
       int dest   = links[i][j].first;
       float weight = links[i][j].second;
       if (type==WEIGHTED)
@@ -129,26 +150,26 @@ Graph::display(int type) {
 }
 
 void
-Graph::display_binary(char *filename, char *filename_w, int type) {
+Graph::display_binary(char *filename, char *filename_w, uint32_t type) {
   ofstream foutput;
   foutput.open(filename, fstream::out | fstream::binary);
 
-  unsigned int s = links.size();
+  uint32_t s = links.size();
 
   // outputs number of nodes
   foutput.write((char *)(&s),4);
 
   // outputs cumulative degree sequence
   long tot=0;
-  for (unsigned int i=0 ; i<s ; i++) {
+  for (uint32_t i=0 ; i<s ; i++) {
     tot+=(long)links[i].size();
     foutput.write((char *)(&tot),8);
   }
 
   // outputs links
-  for (unsigned int i=0 ; i<s ; i++) {
-    for (unsigned int j=0 ; j<links[i].size() ; j++) {
-      int dest = links[i][j].first;
+  for (uint32_t i=0 ; i<s ; i++) {
+    for (uint32_t j=0 ; j<links[i].size() ; j++) {
+      uint32_t dest = links[i][j].first;
       foutput.write((char *)(&dest),4);
     }
   }
@@ -158,8 +179,8 @@ Graph::display_binary(char *filename, char *filename_w, int type) {
   if (type==WEIGHTED) {
     ofstream foutput_w;
     foutput_w.open(filename_w,fstream::out | fstream::binary);
-    for (unsigned int i=0 ; i<s ; i++) {
-      for (unsigned int j=0 ; j<links[i].size() ; j++) {
+    for (uint32_t i=0 ; i<s ; i++) {
+      for (uint32_t j=0 ; j<links[i].size() ; j++) {
 	float weight = links[i][j].second;
 	foutput_w.write((char *)(&weight),4);
       }

--- a/graph.h
+++ b/graph.h
@@ -39,6 +39,8 @@
 #include <map>
 #include <set>
 #include <algorithm>
+#include <cstdint>
+#include <cassert>
 
 #define WEIGHTED   0
 #define UNWEIGHTED 1
@@ -47,14 +49,14 @@ using namespace std;
 
 class Graph {
  public:
-  vector<vector<pair<int,float> > > links;
+  vector<vector<pair<uint32_t,float> > > links;
   
-  Graph (char *filename, int type);
+  Graph (char *filename, uint32_t type);
   
-  void clean(int type);
-  void renumber(int type);
-  void display(int type);
-  void display_binary(char *filename, char *filename_w, int type);
+  void clean(uint32_t type);
+  void renumber(uint32_t type);
+  void display(uint32_t type);
+  void display_binary(char *filename, char *filename_w, uint32_t type);
 };
 
 #endif // GRAPH_H

--- a/graph_binary.cpp
+++ b/graph_binary.cpp
@@ -43,7 +43,7 @@ Graph::Graph(char *filename, char *filename_w, int type) {
   finput.open(filename,fstream::in | fstream::binary);
 
   // Read number of nodes on 4 bytes
-  finput.read((char *)&nb_nodes, 4);
+  finput.read((char *)&nb_nodes, sizeof(nb_nodes));
   assert(finput.rdstate() == ios::goodbit);
 
   // Read cumulative degree sequence: 8 bytes for each node

--- a/graph_binary.h
+++ b/graph_binary.h
@@ -30,10 +30,13 @@
 #ifndef GRAPH_H
 #define GRAPH_H
 
+#if !defined(__MACH__)
+#include <malloc.h>
+#endif
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <assert.h>
-#include <malloc.h>
 #include <iostream>
 #include <iomanip>
 #include <fstream>

--- a/main_community.cpp
+++ b/main_community.cpp
@@ -35,7 +35,7 @@
 #include <sstream>
 #include <vector>
 #include <algorithm>
-
+#include <unistd.h>
 #include "graph_binary.h"
 #include "community.h"
 

--- a/main_community.cpp
+++ b/main_community.cpp
@@ -35,6 +35,7 @@
 #include <sstream>
 #include <vector>
 #include <algorithm>
+#include <unistd.h> // getpid
 
 #include "graph_binary.h"
 #include "community.h"

--- a/main_convert.cpp
+++ b/main_convert.cpp
@@ -34,7 +34,7 @@ using namespace std;
 char *infile   = NULL;
 char *outfile  = NULL;
 char *outfile_w  = NULL;
-int type       = UNWEIGHTED;
+uint32_t type       = UNWEIGHTED;
 bool do_renumber = false;
 
 void


### PR DESCRIPTION
The graphs are written directly to binary format and the rewritten louvain binary "convert" is expecting a binary file to operate on, as it is done in the Phenograph algorithm (https://github.com/jacoblevine/PhenoGraph)